### PR TITLE
Fixed a crash when more than one alert view is displayed at a time

### DIFF
--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -57,7 +57,7 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 	
 }
 
-- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
 {
     NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
     RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];


### PR DESCRIPTION
Currently the alert view does the job (run the block and release itself) in the `- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex` delegate method. This method also gets called when more than one alert view is shown. The crash can easily be reproduced using the following code snippet:

```
UIAlertView *one = [[[UIAlertView alloc] initWithTitle:@"one" message:@"one" cancelButtonItem:[RIButtonItem itemWithLabel:@"dismiss"] otherButtonItems: nil] autorelease];
UIAlertView *two = [[[UIAlertView alloc] initWithTitle:@"two" message:@"two" cancelButtonItem:[RIButtonItem itemWithLabel:@"dismiss"] otherButtonItems: nil] autorelease];
[one show];
[two show];
```

The crash happens when the second alert view is dismissed. To fix it the delegate method was changed to `- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex`
