### PR TITLE
Add support for cancel and destructive bits to items

### DIFF
--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -14,9 +14,16 @@ typedef void (^RISimpleAction)();
 {
     NSString *label;
     RISimpleAction action;
+    
+    struct {
+        unsigned int isCancel:1;
+        unsigned int isDestructive:1;
+    } itemFlags;
 }
 @property (retain, nonatomic) NSString *label;
 @property (copy, nonatomic) RISimpleAction action;
+@property (nonatomic) BOOL isDestructive;
+@property (nonatomic) BOOL isCancel;
 +(id)item;
 +(id)itemWithLabel:(NSString *)inLabel;
 @end

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -33,5 +33,21 @@
     [super dealloc];
 }
 
+-(BOOL)isDestructive {
+    return itemFlags.isDestructive;
+}
+
+-(void)setIsDestructive:(BOOL)isDestructive {
+    itemFlags.isDestructive = isDestructive;
+}
+
+-(BOOL)isCancel {
+    return itemFlags.isCancel;
+}
+
+-(void)setIsCancel:(BOOL)isCancel {
+    itemFlags.isCancel = isCancel;
+}
+
 @end
 

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -60,11 +60,18 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {	
     NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
-	
+
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
+    
+    if (item.isDestructive) {
+        [self setDestructiveButtonIndex:buttonIndex];
+    }
+    if (item.isCancel) {
+        [self setCancelButtonIndex:buttonIndex];
+    }
 	[buttonsArray addObject:item];
 	
-	return buttonIndex;
+    return buttonIndex;
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -53,9 +53,13 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
     NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
 	
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
+    
+    if (item.isCancel) {
+        [self setCancelButtonIndex:buttonIndex];
+    }
 	[buttonsArray addObject:item];
 	
-	return buttonIndex;
+    return buttonIndex;
 }
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex


### PR DESCRIPTION
When you call the standard constructor passing in a cancel and destructive button item and then add additional button items, they destructive and cancel items end up at the top of the action sheet. 

In order to control the order of cancel and destructive I added two property flags to RIButtonItem. When adding an item to an action sheet or alertview this bit determines whether the added item is tagged for cancel or delete status. 

This allows exact control over the order added and what each button's status is. I know this could be done with the addButtonItem returned index, but this way it's all encapsulated in the button item itself. 

You like?
