### PR TITLE
Crash if UIActionSheet dismissed from touch outside popover on iPad

### DIFF
--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -69,11 +69,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
-    RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-    if(item.action)
-        item.action();
-    objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (buttonIndex != -1)
+    {
+        NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
+        RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
+        if(item.action)
+            item.action();
+        objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    
     [self release]; // and release yourself!
 }
 


### PR DESCRIPTION
Fix crash if tap outside popover of UIActionSheet dismisses it without selection. If presented from a UIBarButtonItem and a tap away dismisses the sheet's popover, the buttonIndex is -1 causing an index out of bounds exception.
