### PR TITLE
Fix for UIAlertViews created with init

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (C) 2011 by Random Ideas, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void (^RISimpleAction)();
+
 @interface RIButtonItem : NSObject
 {
     NSString *label;

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -14,7 +14,7 @@
 
 +(id)item
 {
-    return [[self new] autorelease];
+    return [self new];
 }
 
 +(id)itemWithLabel:(NSString *)inLabel
@@ -22,15 +22,6 @@
     id newItem = [self item];
     [newItem setLabel:inLabel];
     return newItem;
-}
-
--(void)dealloc
-{
-    [action release];
-    action = nil;
-    [label release];
-    label = nil;
-    [super dealloc];
 }
 
 @end

--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -17,6 +17,7 @@
 @property (copy, nonatomic) RISimpleAction dismissalAction;
 
 -(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... NS_REQUIRES_NIL_TERMINATION;
+-(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItemsArray:(NSArray *)inOtherButtonItems;
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;
 

--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -21,8 +21,4 @@
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;
 
-/** This block is called when the action sheet is dismssed for any reason.
- */
-@property (copy, nonatomic) void(^dismissalAction)();
-
 @end

--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -11,6 +11,11 @@
 
 @interface UIActionSheet (Blocks) <UIActionSheetDelegate>
 
+/** This block is called when the action sheet is dismssed for any reason other than a button
+ press. If the user taps outside the view, for example. 
+ */
+@property (copy, nonatomic) RISimpleAction dismissalAction;
+
 -(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... NS_REQUIRES_NIL_TERMINATION;
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -9,8 +9,8 @@
 #import "UIActionSheet+Blocks.h"
 #import <objc/runtime.h>
 
-static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
-static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
+static const void *RI_BUTTON_ASS_KEY = &RI_BUTTON_ASS_KEY;
+static const void *RI_DISMISSAL_ACTION_KEY = &RI_DISMISSAL_ACTION_KEY;
 
 @implementation UIActionSheet (Blocks)
 
@@ -52,8 +52,6 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
         }
         
         objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        
-        [self retain]; // keep yourself around!
     }
     return self;
 }
@@ -70,13 +68,13 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
 
 - (void)setDismissalAction:(RISimpleAction)dismissalAction
 {
-    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
-    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, dismissalAction, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(self, RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(self, RI_DISMISSAL_ACTION_KEY, dismissalAction, OBJC_ASSOCIATION_COPY);
 }
 
 - (RISimpleAction)dismissalAction
 {
-    return objc_getAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY);
+    return objc_getAssociatedObject(self, RI_DISMISSAL_ACTION_KEY);
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
@@ -85,7 +83,7 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
     // pressed.
     if (buttonIndex >= 0)
     {
-        NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+        NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
         RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
         if(item.action)
             item.action();
@@ -94,10 +92,8 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
     {
         self.dismissalAction();
     }
-    objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
-	
-	[self release];
+    objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
 }
 
 @end

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -14,30 +14,17 @@ static const void *RI_DISMISSAL_ACTION_KEY = &RI_DISMISSAL_ACTION_KEY;
 
 @implementation UIActionSheet (Blocks)
 
--(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ...
-{
+-(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItemsArray:(NSArray *)inOtherButtonItems {
     if((self = [self initWithTitle:inTitle delegate:self cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil]))
     {
         NSMutableArray *buttonsArray = [NSMutableArray array];
-        
-        RIButtonItem *eachItem;
-        va_list argumentList;
-        if (inOtherButtonItems)
-        {
-            [buttonsArray addObject: inOtherButtonItems];
-            va_start(argumentList, inOtherButtonItems);
-            while((eachItem = va_arg(argumentList, RIButtonItem *)))
-            {
-                [buttonsArray addObject: eachItem];
-            }
-            va_end(argumentList);
-        }
-        
+        [buttonsArray addObjectsFromArray:inOtherButtonItems];
+
         for(RIButtonItem *item in buttonsArray)
         {
             [self addButtonWithTitle:item.label];
         }
-        
+
         if(inDestructiveItem)
         {
             [buttonsArray addObject:inDestructiveItem];
@@ -52,9 +39,29 @@ static const void *RI_DISMISSAL_ACTION_KEY = &RI_DISMISSAL_ACTION_KEY;
         }
         
         objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        
     }
+
     return self;
+}
+
+-(id)initWithTitle:(NSString *)inTitle cancelButtonItem:(RIButtonItem *)inCancelButtonItem destructiveButtonItem:(RIButtonItem *)inDestructiveItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ...
+{
+    NSMutableArray *buttonsArray = [NSMutableArray array];
+
+    RIButtonItem *eachItem;
+    va_list argumentList;
+    if (inOtherButtonItems)
+    {
+        [buttonsArray addObject: inOtherButtonItems];
+        va_start(argumentList, inOtherButtonItems);
+        while((eachItem = va_arg(argumentList, RIButtonItem *)))
+        {
+            [buttonsArray addObject: eachItem];
+        }
+        va_end(argumentList);
+    }
+
+    return [self initWithTitle:inTitle cancelButtonItem:inCancelButtonItem destructiveButtonItem:inDestructiveItem otherButtonItemsArray:buttonsArray];
 }
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -66,7 +66,7 @@ static const void *RI_DISMISSAL_ACTION_KEY = &RI_DISMISSAL_ACTION_KEY;
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {	
-    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);	
+    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
 	
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
 	[buttonsArray addObject:item];
@@ -91,7 +91,7 @@ static const void *RI_DISMISSAL_ACTION_KEY = &RI_DISMISSAL_ACTION_KEY;
     // pressed.
     if (buttonIndex >= 0)
     {
-        NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+        NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
         RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
         if(item.action)
             item.action();

--- a/UIAlertView+Blocks.h
+++ b/UIAlertView+Blocks.h
@@ -12,6 +12,7 @@
 @interface UIAlertView (Blocks)
 
 -(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... NS_REQUIRES_NIL_TERMINATION;
+-(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItemsArray:(NSArray *)inOtherButtonItemsArray;
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;
 

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -51,9 +51,19 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {	
     NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
+    
+    if (buttonsArray == nil) {
+    	buttonsArray = [NSMutableArray array];
+    	objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
 	
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
 	[buttonsArray addObject:item];
+	
+	if ([self delegate] == nil) {
+		[self setDelegate:self];
+		[self retain];
+	}
 	
 	return buttonIndex;
 }

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -9,7 +9,7 @@
 #import "UIAlertView+Blocks.h"
 #import <objc/runtime.h>
 
-static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
+static const void *RI_BUTTON_ASS_KEY = &RI_BUTTON_ASS_KEY;
 
 @implementation UIAlertView (Blocks)
 
@@ -43,7 +43,6 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         
         [self setDelegate:self];
-        [self retain]; // keep yourself around!
     }
     return self;
 }
@@ -62,7 +61,6 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 	
 	if ([self delegate] == nil) {
 		[self setDelegate:self];
-		[self retain];
 	}
 	
 	return buttonIndex;
@@ -75,7 +73,6 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
     if(item.action)
         item.action();
     objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self release]; // and release yourself!
 }
 
 @end

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -13,38 +13,49 @@ static const void *RI_BUTTON_ASS_KEY = &RI_BUTTON_ASS_KEY;
 
 @implementation UIAlertView (Blocks)
 
+-(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItemsArray:(NSArray *)inOtherButtonItemsArray
+{
+    self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]
+
+    if (self) {
+        NSMutableArray *buttonsArray = [NSMutableArray array];
+        [buttonsArray addObjectsFromArray:inOtherButtonItemsArray];
+
+        for (RIButtonItem *item in buttonsArray)
+        {
+            [self addButtonWithTitle:item.label];
+        }
+
+        if (inCancelButtonItem) {
+            [buttonsArray insertObject:inCancelButtonItem atIndex:0];
+	}
+
+        objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        [self setDelegate:self];
+    }
+
+    return self;
+}
+
 -(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... 
 {
-	if((self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]))
-	{
-		NSMutableArray *buttonsArray = [NSMutableArray array];
-		
-		RIButtonItem *eachItem;
-		va_list argumentList;
-		if (inOtherButtonItems)					 
-		{								  
-			[buttonsArray addObject: inOtherButtonItems];
-			va_start(argumentList, inOtherButtonItems);	   
-			while((eachItem = va_arg(argumentList, RIButtonItem *))) 
-			{
-				[buttonsArray addObject: eachItem];			
-			}
-			va_end(argumentList);
-		}	
-		
-		for(RIButtonItem *item in buttonsArray)
-		{
-			[self addButtonWithTitle:item.label];
-		}
-		
-		if(inCancelButtonItem)
-			[buttonsArray insertObject:inCancelButtonItem atIndex:0];
-		
-		objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-		
-		[self setDelegate:self];
-	}
-	return self;
+    NSMutableArray *buttonsArray = [NSMutableArray array];
+
+    RIButtonItem *eachItem;
+    va_list argumentList;
+    if (inOtherButtonItems)
+    {
+        [buttonsArray addObject: inOtherButtonItems];
+        va_start(argumentList, inOtherButtonItems);
+        while((eachItem = va_arg(argumentList, RIButtonItem *)))
+        {
+            [buttonsArray addObject: eachItem];
+        }
+        va_end(argumentList);
+    }
+
+    return [self initWithTitle:inTitle message:inMessage cancelButtonItem:inCancelButtonItem otherButtonItemsArray:buttonsArray];
 }
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
@@ -68,24 +79,18 @@ static const void *RI_BUTTON_ASS_KEY = &RI_BUTTON_ASS_KEY;
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
 {
-<<<<<<< HEAD
-	NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
-	RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-	if(item.action)
-		item.action();
-	objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-=======
 	// If the button index is -1 it means we were dismissed with no selection
 	if (buttonIndex >= 0)
 	{
-		NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+		NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
 		RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-		if(item.action)
+
+		if (item.action) {
 			item.action();
+		}
 	}
 	
-	objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
->>>>>>> upstream/master
+	objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -15,7 +15,7 @@ static const void *RI_BUTTON_ASS_KEY = &RI_BUTTON_ASS_KEY;
 
 -(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItemsArray:(NSArray *)inOtherButtonItemsArray
 {
-    self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]
+    self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil];
 
     if (self) {
         NSMutableArray *buttonsArray = [NSMutableArray array];

--- a/UIAlertView-Blocks.podspec
+++ b/UIAlertView-Blocks.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "UIAlertView-Blocks"
+  s.version      = "0.0.1"
+  s.summary      = "A category for UIAlertView which allows you to use blocks to handle the pressed button events rather than implementing a delegate."
+  s.homepage     = "https://github.com/SlaunchaMan/UIAlertView-Blocks"
+  s.license      = 'MIT'
+  s.authors      = { "Jeff Kelley" => "SlaunchaMan@gmail.com", "Jiva DeVoe" => "info@random-ideas.net" }
+  s.source       = { :git => "https://github.com/SlaunchaMan/UIAlertView-Blocks.git", :commit => "814db348b919220e2d49796ce778c02dd27f9460" }
+  s.platform     = :ios
+  s.source_files = '*.{h,m}'
+  s.frameworks   = 'UIKit', 'Foundation'
+  s.requires_arc = true
+end


### PR DESCRIPTION
If you create an alert view like so:

```
UIAlertView *someAlertView = [[UIAlertView alloc] init];
```

and then later call:

```
[someAlertView addButtonItem:myItem];
```

The item’s action will never be called. This pull request duplicates the set-up code in `-addButtonItem:` to prevent that from occurring.
