### PR TITLE
Converted project to ARC and added a dismissal block.

### DIFF
--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -15,7 +15,7 @@ typedef void (^RISimpleAction)();
     NSString *label;
     RISimpleAction action;
 }
-@property (retain, nonatomic) NSString *label;
+@property (strong, nonatomic) NSString *label;
 @property (copy, nonatomic) RISimpleAction action;
 +(id)item;
 +(id)itemWithLabel:(NSString *)inLabel;

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -14,7 +14,7 @@
 
 +(id)item
 {
-    return [[self new] autorelease];
+    return [self new];
 }
 
 +(id)itemWithLabel:(NSString *)inLabel
@@ -22,15 +22,6 @@
     id newItem = [self item];
     [newItem setLabel:inLabel];
     return newItem;
-}
-
--(void)dealloc
-{
-    [action release];
-    action = nil;
-    [label release];
-    label = nil;
-    [super dealloc];
 }
 
 @end

--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -15,8 +15,7 @@
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;
 
-/** This block is called when the action sheet is dismssed for any reason other than a button
-    press. If the user taps outside the view, for example. 
+/** This block is called when the action sheet is dismssed for any reason.
  */
 @property (copy, nonatomic) RISimpleAction dismissalAction;
 

--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -15,4 +15,9 @@
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item;
 
+/** This block is called when the action sheet is dismssed for any reason other than a button
+    press. If the user taps outside the view, for example. 
+ */
+@property (copy, nonatomic) RISimpleAction dismissalAction;
+
 @end

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -10,6 +10,7 @@
 #import <objc/runtime.h>
 
 static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
+static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
 
 @implementation UIActionSheet (Blocks)
 
@@ -66,6 +67,17 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 	return buttonIndex;
 }
 
+- (void)setDismissalAction:(RISimpleAction)dismissalAction
+{
+    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, dismissalAction, OBJC_ASSOCIATION_COPY);
+}
+
+- (RISimpleAction)dismissalAction
+{
+    return objc_getAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY);
+}
+
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
     // Action sheets pass back -1 when they're cleared for some reason other than a button being 
@@ -77,7 +89,12 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         if(item.action)
             item.action();
     }
+    else if (self.dismissalAction)
+    {
+        self.dismissalAction();
+    }
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
 }
 
 @end

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -50,16 +50,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
             [self setCancelButtonIndex:cancelIndex];
         }
         
-        objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         
-        [self retain]; // keep yourself around!
     }
     return self;
 }
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {	
-    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
+    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);	
 	
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
 	[buttonsArray addObject:item];
@@ -69,12 +68,11 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
+    NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
     RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
     if(item.action)
         item.action();
-    objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self release]; // and release yourself!
+    objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -89,10 +89,9 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
         if(item.action)
             item.action();
     }
-    else if (self.dismissalAction)
-    {
-        self.dismissalAction();
-    }
+    
+    if (self.dismissalAction) self.dismissalAction();
+    
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
 }

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -68,10 +68,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
-    RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-    if(item.action)
-        item.action();
+    // Action sheets pass back -1 when they're cleared for some reason other than a button being 
+    // pressed.
+    if (buttonIndex >= 0)
+    {
+        NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+        RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
+        if(item.action)
+            item.action();
+    }
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -59,10 +59,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
-    RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-    if(item.action)
-        item.action();
+    // If the button index is -1 it means we were dismissed with no selection
+    if (buttonIndex >= 0)
+    {
+        NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+        RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
+        if(item.action)
+            item.action();
+    }
+    
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -40,17 +40,16 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         if(inCancelButtonItem)
             [buttonsArray insertObject:inCancelButtonItem atIndex:0];
         
-        objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         
         [self setDelegate:self];
-        [self retain]; // keep yourself around!
     }
     return self;
 }
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {	
-    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);	
+    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);	
 	
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
 	[buttonsArray addObject:item];
@@ -60,12 +59,11 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
+    NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
     RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
     if(item.action)
         item.action();
-    objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    [self release]; // and release yourself!
+    objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end


### PR DESCRIPTION
The ARC conversion is self-explanitory. The dismissal block is called when the alert view dismisses without a button touch. Useful if you need to perform some action when the view disappears.
