### PR TITLE
Replace action block typedef with literal type

### DIFF
--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -8,15 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (^RISimpleAction)();
-
 @interface RIButtonItem : NSObject
 {
     NSString *label;
-    RISimpleAction action;
+    void (^action)();
 }
 @property (retain, nonatomic) NSString *label;
-@property (copy, nonatomic) RISimpleAction action;
+@property (copy, nonatomic) void (^action)();
 +(id)item;
 +(id)itemWithLabel:(NSString *)inLabel;
 @end


### PR DESCRIPTION
Using the literal typedef makes Xcode's code completion give you a parameter stand-in that can be expanded with a shift-enter.

With the typedef, Xcode's code completion expands setAction: to:
    [cancelButton setAction:<#(RISimpleAction)action#>
And it doesn't know what to do with the parameter type.

With a literal type definition inline, Xcode's code completion expands setAction to:
    [cancelButton setAction:<#(void (^)())action#>
And if you hit shift-enter on the parameter it gives you:
    [cancelButton setAction:^{
        <#code#>
    }

It's not really that important, and with such a simple block type it doesn't really save any typing, but I've gotten in the habit of expanding block completions.
