### PR TITLE
Convert RISimpleAction in UIActionSheet+Blocks to void block literal

### DIFF
--- a/UIActionSheet+Blocks.h
+++ b/UIActionSheet+Blocks.h
@@ -17,6 +17,6 @@
 
 /** This block is called when the action sheet is dismssed for any reason.
  */
-@property (copy, nonatomic) RISimpleAction dismissalAction;
+@property (copy, nonatomic) void(^dismissalAction)();
 
 @end

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -67,13 +67,13 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
 	return buttonIndex;
 }
 
-- (void)setDismissalAction:(RISimpleAction)dismissalAction
+- (void)setDismissalAction:(void(^)())dismissalAction
 {
     objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, nil, OBJC_ASSOCIATION_COPY);
     objc_setAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY, dismissalAction, OBJC_ASSOCIATION_COPY);
 }
 
-- (RISimpleAction)dismissalAction
+- (void(^)())dismissalAction
 {
     return objc_getAssociatedObject(self, (__bridge const void *)RI_DISMISSAL_ACTION_KEY);
 }


### PR DESCRIPTION
RISimpleAction typedef does not exist in these files anymore, so this class wasn't compiling. Changed to literals to match UIAlertView+Blocks
