### PR TITLE
Use concrete type in itemWithLabel instead of id

### DIFF
--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -19,7 +19,7 @@
 
 +(id)itemWithLabel:(NSString *)inLabel
 {
-    id newItem = [self item];
+    RIButtonItem *newItem = [self item];
     [newItem setLabel:inLabel];
     return newItem;
 }

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -69,11 +69,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
-    RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
-    if(item.action)
-        item.action();
-    objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (buttonIndex != -1)
+    {
+        NSArray *buttonsArray = objc_getAssociatedObject(self, RI_BUTTON_ASS_KEY);
+        RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
+        if(item.action)
+            item.action();
+        objc_setAssociatedObject(self, RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    
     [self release]; // and release yourself!
 }
 


### PR DESCRIPTION
If something else in a project has an object with a label property and that class is ahead of RIButton in the imports, the compiler gives a warning that setLabel: is possibly receiving the wrong type.

Switching to the concrete RIButtonItem type clears this warning. There should be no adverse impact that I'm aware of.
