### PR TITLE
This fixes a compile error related to setAction: not being a unique selector. See commit for more details.

### DIFF
--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -26,7 +26,7 @@
 
 +(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action
 {
-  id newItem = [self itemWithLabel:inLabel];
+  RIButtonItem *newItem = [self itemWithLabel:inLabel];
   [newItem setAction:action];
   return newItem;
 }


### PR DESCRIPTION
When newItem below is of type id, then setAction can match a number of selectors. E.g. UIMenuItem action property which takes SEL types. This fix changes newItem to type RIButtonItem so compiler can marshal parameters for method call correctly. See http://www.cocoawithlove.com/2011/06/big-weakness-of-objective-c-weak-typing.html

```
id newItem = [self itemWithLabel:inLabel];
[newItem setAction:action];
```
