### PR TITLE
Making compiler happy

### DIFF
--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -26,7 +26,7 @@
 
 +(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action
 {
-  id newItem = [self itemWithLabel:inLabel];
+  RIButtonItem *newItem = [self itemWithLabel:inLabel];
   [newItem setAction:action];
   return newItem;
 }


### PR DESCRIPTION
As far as I understand `itemWithLabel:` support to return `RIButtonItem` or one of the subclasses
If not casted to RIButton, I'm getting `Sending 'void (^__strong)(void)' to parameter of incompatible type 'SEL' (aka 'SEL *')` compiler error
Although I do understand it might be a compiler issue (it thinks newItem is a `UIBarButtonItem` instance), 
it prevents me from compiling project:)
Thank you!
