### PR TITLE
Add view to action blocks

### DIFF
--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -17,8 +17,8 @@ typedef void(^RIButtonItemAction)(id view);
 }
 @property (retain, nonatomic) NSString *label;
 @property (copy, nonatomic) RIButtonItemAction action;
-+(id)item;
-+(id)itemWithLabel:(NSString *)inLabel;
-+(id)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action;
++(instancetype)item;
++(instancetype)itemWithLabel:(NSString *)inLabel;
++(instancetype)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action;
 @end
 

--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -8,15 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
+typedef void(^RIButtonItemAction)(id view);
+
 @interface RIButtonItem : NSObject
 {
     NSString *label;
-    void (^action)();
+    RIButtonItemAction action;
 }
 @property (retain, nonatomic) NSString *label;
-@property (copy, nonatomic) void (^action)();
+@property (copy, nonatomic) RIButtonItemAction action;
 +(id)item;
 +(id)itemWithLabel:(NSString *)inLabel;
-+(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action;
++(id)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action;
 @end
 

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -12,23 +12,23 @@
 @synthesize label;
 @synthesize action;
 
-+(id)item
++(instancetype)item
 {
     return [self new];
 }
 
-+(id)itemWithLabel:(NSString *)inLabel
++(instancetype)itemWithLabel:(NSString *)inLabel
 {
     RIButtonItem *newItem = [self item];
     [newItem setLabel:inLabel];
     return newItem;
 }
 
-+(id)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action
++(instancetype)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action
 {
-  id newItem = [self itemWithLabel:inLabel];
-  [newItem setAction:action];
-  return newItem;
+    RIButtonItem *newItem = [self itemWithLabel:inLabel];
+    [newItem setAction:action];
+    return newItem;
 }
 
 @end

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -24,7 +24,7 @@
     return newItem;
 }
 
-+(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action
++(id)itemWithLabel:(NSString *)inLabel action:(RIButtonItemAction)action
 {
   id newItem = [self itemWithLabel:inLabel];
   [newItem setAction:action];

--- a/UIActionSheet+Blocks.m
+++ b/UIActionSheet+Blocks.m
@@ -87,7 +87,7 @@ static NSString *RI_DISMISSAL_ACTION_KEY = @"com.random-ideas.DISMISSAL_ACTION";
         NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
         RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
         if(item.action)
-            item.action();
+            item.action(actionSheet);
     }
     
     if (self.dismissalAction) self.dismissalAction();

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -65,7 +65,7 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         NSArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
         RIButtonItem *item = [buttonsArray objectAtIndex:buttonIndex];
         if(item.action)
-            item.action();
+            item.action(alertView);
     }
     
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
Sometimes you need a reference to the actual UIAlertView, for example to get the values out of UITextFields. This change adds the UIAlertView or UIActionSheet to the action block. 

It breaks backward compatibility, but I didn't want to introduce a second action property, which I thought could be buggy. Updating calling code is straightforward--you just add an `id view` parameter to the action block.
