### PR TITLE
Adding PodSpec for CocoaPods repository

### DIFF
--- a/UIAlertView-Blocks.podspec
+++ b/UIAlertView-Blocks.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         =  'UIAlertView-Blocks'
+  s.version      =  '0.0.2'
+  s.platform     =  :ios
+  s.author       =  'Jiva Devoe'
+  s.license      =  'MIT'
+  s.requires_arc =  true
+  s.summary      =  'Category for UIAlertView and UIActionSheet which allows you to use blocks rather than implementing a delegate.'
+  s.description  =  'A category for UIAlertView and UIActionSheet which allows you to use blocks to handle the pressed button events rather than implementing a delegate.'
+  s.source_files =  '*.{h,m}'
+  s.homepage     =  'https://github.com/jivadevoe/UIAlertView-Blocks'
+  s.source       =  { :git => 'https://github.com/jivadevoe/UIAlertView-Blocks.git', :commit => '1268fa5ecc0be6d933d8e0c871018b8b1dd4fe64' }
+end


### PR DESCRIPTION
Hi, 

Not sure if you know, but there's currently a podspec for UIAlertView-Blocks on CocoaPods (http://cocoapods.org/?q=name%3Auialertview), though I've noticed it hasn't been updated in over a year.  

I've just used the existing podspec on the CocoaPods site, but updated it to the latest commit in this repo, and sent them a pull request to include it (https://github.com/CocoaPods/Specs/pull/3640).

You don't really need to check this file in, though it would be handy to have it around so the next person who updates the podspec can just re-use this file.

Thanks!
