### PR TITLE
Adds a reference to tag 1.0 in the Podspec source parameters

### DIFF
--- a/UIAlertView-Blocks.podspec
+++ b/UIAlertView-Blocks.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.description  =  'A category for UIAlertView and UIActionSheet which allows you to use blocks to handle the pressed button events rather than implementing a delegate.'
   s.source_files =  '*.{h,m}'
   s.homepage     =  'https://github.com/jivadevoe/UIAlertView-Blocks'
-  s.source       =  { :git => 'https://github.com/jivadevoe/UIAlertView-Blocks.git' }
+  s.source       =  { :git => 'https://github.com/jivadevoe/UIAlertView-Blocks.git', :tag => '1.0' }
 end


### PR DESCRIPTION
Regarding the comments on this commit: https://github.com/jivadevoe/UIAlertView-Blocks/commit/eacae079edded01e3a3aa5d27256419e46f2db6e
