### PR TITLE
Make the Podspec pass the pod spec validation ('pod spec lint')

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/UIAlertView-Blocks.podspec
+++ b/UIAlertView-Blocks.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name         =  'UIAlertView-Blocks'
-  s.version      =  '1.0.0'
+  s.version      =  '1.0'
   s.platform     =  :ios
   s.author       =  'Jiva Devoe'
-  s.license      =  'MIT'
+  s.license      =  { :type => 'MIT', :file => 'LICENSE' }
   s.requires_arc =  true
   s.summary      =  'Category for UIAlertView and UIActionSheet which allows you to use blocks rather than implementing a delegate.'
   s.description  =  'A category for UIAlertView and UIActionSheet which allows you to use blocks to handle the pressed button events rather than implementing a delegate.'


### PR DESCRIPTION
I made the Podspec version match the tagged version and added an MIT license file. Both were issues needed to be resolved for the Podspec to pass the 'pod spec lint' validation.

Sorry about the back and forth. As the Podspec now pass validation everything should be good to go. Thanks for taking the time to handle all of this.
