### PR TITLE
Create button item array on demand, making sure it's non-nil.

### DIFF
--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -13,7 +13,7 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 @implementation UIAlertView (Blocks)
 
--(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... 
+- (id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ...
 {
     if((self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]))
     {
@@ -21,16 +21,16 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         
         RIButtonItem *eachItem;
         va_list argumentList;
-        if (inOtherButtonItems)                     
-        {                                  
+        if (inOtherButtonItems)
+        {
             [buttonsArray addObject: inOtherButtonItems];
-            va_start(argumentList, inOtherButtonItems);       
-            while((eachItem = va_arg(argumentList, RIButtonItem *))) 
+            va_start(argumentList, inOtherButtonItems);
+            while((eachItem = va_arg(argumentList, RIButtonItem *)))
             {
-                [buttonsArray addObject: eachItem];            
+                [buttonsArray addObject: eachItem];
             }
             va_end(argumentList);
-        }    
+        }
         
         for(RIButtonItem *item in buttonsArray)
         {
@@ -47,15 +47,15 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
 {
-	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
-	[[self buttonItems] addObject:item];
-	
-	if (![self delegate])
-	{
-		[self setDelegate:self];
-	}
-	
-	return buttonIndex;
+    NSInteger buttonIndex = [self addButtonWithTitle:item.label];
+    [[self buttonItems] addObject:item];
+    
+    if (![self delegate])
+    {
+        [self setDelegate:self];
+    }
+    
+    return buttonIndex;
 }
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
@@ -72,16 +72,16 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(NSMutableArray *)buttonItems
+- (NSMutableArray *)buttonItems
 {
-	NSMutableArray *buttonItems = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
-	if (!buttonItems)
-	{
-		buttonItems = [NSMutableArray array];
-		objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonItems, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-	}
-	
-	return buttonItems;
+    NSMutableArray *buttonItems = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+    if (!buttonItems)
+    {
+        buttonItems = [NSMutableArray array];
+        objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonItems, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    
+    return buttonItems;
 }
 
 @end

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -13,24 +13,24 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 @implementation UIAlertView (Blocks)
 
--(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... 
+-(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ...
 {
     if((self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]))
     {
-        NSMutableArray *buttonsArray = [NSMutableArray array];
+        NSMutableArray *buttonsArray = [self buttonItems];
         
         RIButtonItem *eachItem;
         va_list argumentList;
-        if (inOtherButtonItems)                     
-        {                                  
+        if (inOtherButtonItems)
+        {
             [buttonsArray addObject: inOtherButtonItems];
-            va_start(argumentList, inOtherButtonItems);       
-            while((eachItem = va_arg(argumentList, RIButtonItem *))) 
+            va_start(argumentList, inOtherButtonItems);
+            while((eachItem = va_arg(argumentList, RIButtonItem *)))
             {
-                [buttonsArray addObject: eachItem];            
+                [buttonsArray addObject: eachItem];
             }
             va_end(argumentList);
-        }    
+        }
         
         for(RIButtonItem *item in buttonsArray)
         {
@@ -40,19 +40,20 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         if(inCancelButtonItem)
             [buttonsArray insertObject:inCancelButtonItem atIndex:0];
         
-        objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-        
         [self setDelegate:self];
     }
     return self;
 }
 
 - (NSInteger)addButtonItem:(RIButtonItem *)item
-{	
-    NSMutableArray *buttonsArray = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);	
-	
+{
 	NSInteger buttonIndex = [self addButtonWithTitle:item.label];
-	[buttonsArray addObject:item];
+	[[self buttonItems] addObject:item];
+	
+	if (![self delegate])
+	{
+		[self setDelegate:self];
+	}
 	
 	return buttonIndex;
 }
@@ -69,6 +70,18 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
     }
     
     objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+-(NSMutableArray *)buttonItems
+{
+	NSMutableArray *buttonItems = objc_getAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY);
+	if (!buttonItems)
+	{
+		buttonItems = [NSMutableArray array];
+		objc_setAssociatedObject(self, (__bridge const void *)RI_BUTTON_ASS_KEY, buttonItems, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	}
+	
+	return buttonItems;
 }
 
 @end

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -13,7 +13,7 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
 
 @implementation UIAlertView (Blocks)
 
--(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ...
+-(id)initWithTitle:(NSString *)inTitle message:(NSString *)inMessage cancelButtonItem:(RIButtonItem *)inCancelButtonItem otherButtonItems:(RIButtonItem *)inOtherButtonItems, ... 
 {
     if((self = [self initWithTitle:inTitle message:inMessage delegate:self cancelButtonTitle:inCancelButtonItem.label otherButtonTitles:nil]))
     {
@@ -21,16 +21,16 @@ static NSString *RI_BUTTON_ASS_KEY = @"com.random-ideas.BUTTONS";
         
         RIButtonItem *eachItem;
         va_list argumentList;
-        if (inOtherButtonItems)
-        {
+        if (inOtherButtonItems)                     
+        {                                  
             [buttonsArray addObject: inOtherButtonItems];
-            va_start(argumentList, inOtherButtonItems);
-            while((eachItem = va_arg(argumentList, RIButtonItem *)))
+            va_start(argumentList, inOtherButtonItems);       
+            while((eachItem = va_arg(argumentList, RIButtonItem *))) 
             {
-                [buttonsArray addObject: eachItem];
+                [buttonsArray addObject: eachItem];            
             }
             va_end(argumentList);
-        }
+        }    
         
         for(RIButtonItem *item in buttonsArray)
         {


### PR DESCRIPTION
When the alert view is created without using the init method in the category the button items array would be nil, causing the actions associated with new RIButtonItems to not fire. Also sets the delegate if needed.
