### PR TITLE
Updated constructors to return instancetype to improve swift compatibility

### DIFF
--- a/RIButtonItem.h
+++ b/RIButtonItem.h
@@ -15,8 +15,8 @@
 }
 @property (retain, nonatomic) NSString *label;
 @property (copy, nonatomic) void (^action)();
-+(id)item;
-+(id)itemWithLabel:(NSString *)inLabel;
-+(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action;
++(instancetype)item;
++(instancetype)itemWithLabel:(NSString *)inLabel;
++(instancetype)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action;
 @end
 

--- a/RIButtonItem.m
+++ b/RIButtonItem.m
@@ -12,19 +12,19 @@
 @synthesize label;
 @synthesize action;
 
-+(id)item
++(instancetype)item
 {
     return [self new];
 }
 
-+(id)itemWithLabel:(NSString *)inLabel
++(instancetype)itemWithLabel:(NSString *)inLabel
 {
     RIButtonItem *newItem = [self item];
     [newItem setLabel:inLabel];
     return newItem;
 }
 
-+(id)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action
++(instancetype)itemWithLabel:(NSString *)inLabel action:(void(^)(void))action
 {
   RIButtonItem *newItem = [self itemWithLabel:inLabel];
   [newItem setAction:action];


### PR DESCRIPTION
When using UIAlertView+Blocks in swift, the `id` constructors are exposed as static methods returning `AnyObject!`:

<img width="572" alt="ributton-old" src="https://cloud.githubusercontent.com/assets/711533/9399362/13623816-4768-11e5-975c-716d27958f47.png">

Updating them to return `instancetype` exposes some more expected initializers:

<img width="452" alt="ributtonitem-fixed" src="https://cloud.githubusercontent.com/assets/711533/9399364/1a052a3e-4768-11e5-897f-c77fd3298d46.png">

It actually feels like more of a side effect than a direct result of this change, but the `instancetype` methods feel cleaner and the result is more usable in Swift.
